### PR TITLE
fix: Enable keyboard controls by removing platform check

### DIFF
--- a/venv/galaxy.py
+++ b/venv/galaxy.py
@@ -75,9 +75,8 @@ class MainWidget(RelativeLayout):
         self.init_ship()
         self.reset_game()
 
-        if self.is_desktop():
-            Window.bind(on_key_down=self._on_keyboard_down)
-            Window.bind(on_key_up=self._on_keyboard_up)
+        Window.bind(on_key_down=self._on_keyboard_down)
+        Window.bind(on_key_up=self._on_keyboard_up)
 
         Clock.schedule_interval(self.update, 1.0 / 60.0)
         self.sound_galaxy.play()


### PR DESCRIPTION
This change fixes a persistent bug where keyboard controls were not working. The root cause was found to be a platform check (`is_desktop()`) that prevented the keyboard event handlers from being bound in certain environments.

By removing this conditional check, the keyboard controls are now initialized unconditionally, ensuring that the 'Enter' key and arrow keys work as expected.

This commit also includes previous refactoring work that simplifies the code structure and removes conflicting mouse/touch controls.