### PR TITLE
feat: Add lives system and active shield explosion

### DIFF
--- a/venv/galaxy.kv
+++ b/venv/galaxy.kv
@@ -24,4 +24,4 @@ MainWidget:
         font_size: dp(20)
         font_name: 'fonts/Eurostile.ttf'
         size_hint: .18, .2
-        pos_hint: {"right": 1, "top": 1}
+        pos_hint: {"x": 0, "y": 0}

--- a/venv/galaxy.py
+++ b/venv/galaxy.py
@@ -70,7 +70,8 @@ class MainWidget(RelativeLayout):
     menu_button_title = StringProperty("START")
     score_txt = StringProperty()
     shield_txt = StringProperty()
-    shield_level = NumericProperty(3)
+    shield_level = NumericProperty(4)
+    last_life_award_score = NumericProperty(0)
 
     sound_begin = None
     sound_begin = None
@@ -133,8 +134,9 @@ class MainWidget(RelativeLayout):
         self.obstacles_coordinates = []
         self.lasers = []
         self.explosions = []
-        self.shield_level = 3
-        self.shield_txt = "SHIELDS: " + str(self.shield_level)
+        self.shield_level = 4
+        self.last_life_award_score = 0
+        self.shield_txt = "LIVES: " + str(self.shield_level)
         self.score_txt = "SCORE: " + str(self.current_y_loop)
         self.pre_fill_tiles_coordinates()
         self.generate_tiles_coordinates()
@@ -467,9 +469,20 @@ class MainWidget(RelativeLayout):
                 distance = (dx**2 + dy**2)**0.5
                 if distance < shield_diameter/2 + obstacle_widget.size[0]/2:
                     self.obstacles_coordinates.remove(obstacle_coord)
+
+                    # Add explosion
+                    explosion = Rectangle(
+                        source="images/explosion.jpg",
+                        pos=(obstacle_widget.pos[0] - obstacle_widget.size[0] / 2, obstacle_widget.pos[1] - obstacle_widget.size[1] / 2),
+                        size=(obstacle_widget.size[0] * 2, obstacle_widget.size[1] * 2)
+                    )
+                    self.explosions.append(explosion)
+                    self.canvas.add(explosion)
+
                     obstacle_widget.size = (0, 0)
                     if self.sound_explosion:
                         self.sound_explosion.play()
+                    Clock.schedule_once(lambda dt: self.remove_explosion(explosion), 0.5)
 
     def update(self, dt):
         time_factor = dt*60
@@ -490,6 +503,10 @@ class MainWidget(RelativeLayout):
                 self.current_offset_y -= spacing_y
                 self.current_y_loop += 1
                 self.score_txt = "SCORE: " + str(self.current_y_loop)
+                if self.current_y_loop >= self.last_life_award_score + 50:
+                    self.last_life_award_score += 50
+                    self.shield_level += 1
+                    self.shield_txt = "LIVES: " + str(self.shield_level)
                 self.generate_tiles_coordinates()
                 print("loop : " + str(self.current_y_loop))
 
@@ -504,7 +521,7 @@ class MainWidget(RelativeLayout):
             for i, obstacle_coord in enumerate(self.obstacles_coordinates[:]):
                 if self.check_ship_collision_with_tile(obstacle_coord[0], obstacle_coord[1]):
                     self.shield_level -= 1
-                    self.shield_txt = "SHIELDS: " + str(self.shield_level)
+                    self.shield_txt = "LIVES: " + str(self.shield_level)
                     self.obstacles_coordinates.remove(obstacle_coord)
                     self.obstacles[i].size = (0, 0)
                     if self.shield_level == 0:


### PR DESCRIPTION
This commit implements a lives system and enhances the active shield feature based on your feedback.

The changes include:
1.  **Lives System:** The shield system has been renamed to a lives system. The player now starts with 4 lives and gains an extra life every 50 points. The lives count is displayed at the bottom-left of the screen.
2.  **Shield-Obstacle Interaction:** The active shield now creates a visual explosion effect when it destroys an obstacle.