### PR TITLE
fix: Change 'fall off path' to cost a life instead of game over

### DIFF
--- a/venv/galaxy.py
+++ b/venv/galaxy.py
@@ -530,9 +530,18 @@ class MainWidget(RelativeLayout):
                 if self.ship_invincible_time <= 0:
                     self.ship_invincible = False
 
-            if not self.check_ship_collision():
-                self.trigger_game_over()
-                return
+            if not self.check_ship_collision() and not self.ship_invincible:
+                self.lives -= 1
+                self.lives_txt = "LIVES: " + str(self.lives)
+                self.ship_invincible = True
+                self.ship_invincible_time = 1.5
+                self.current_offset_x = 0
+                if self.lives == 0:
+                    self.trigger_game_over()
+                    return
+                else:
+                    if self.sound_gameover_impact:
+                        self.sound_gameover_impact.play()
 
             for i, obstacle_coord in enumerate(self.obstacles_coordinates[:]):
                 if self.check_ship_collision_with_tile(obstacle_coord[0], obstacle_coord[1]):


### PR DESCRIPTION
This commit changes the game logic for when the player's vehicle leaves the designated path. Instead of an immediate game over, this event now costs one life.

The changes include:
1.  **Updated Game Logic:** The `update` method now checks if the player is off the path. If so, it decrements the player's life count.
2.  **Player Repositioning:** After falling off, the player's horizontal position is reset to the center of the track to allow them to continue playing.
3.  **Temporary Invincibility:** A brief period of invincibility is granted after falling off to prevent an immediate subsequent loss of life.
4.  **Game Over Condition:** The game now only ends when the player's life count reaches zero, from either falling off or colliding with obstacles.