### PR TITLE
Revert explosion blending to fix visibility

### DIFF
--- a/venv/galaxy.py
+++ b/venv/galaxy.py
@@ -15,8 +15,7 @@ from kivy.core.window import Window
 from kivy.app import App
 from kivy.graphics.context_instructions import Color
 from kivy.graphics.vertex_instructions import Line, Quad, Triangle, Ellipse, Rectangle
-from kivy.graphics.instructions import InstructionGroup, Callback
-from kivy.graphics.opengl import glBlendFunc, GL_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA
+from kivy.graphics.instructions import InstructionGroup
 from kivy.properties import NumericProperty, Clock, ObjectProperty, StringProperty, BooleanProperty
 from kivy.uix.widget import Widget
 from kivy.uix.button import Button
@@ -574,23 +573,18 @@ class MainWidget(RelativeLayout):
                     self.on_obstacle_destroyed()
 
                     # Add explosion
-                    explosion_group = InstructionGroup()
-                    explosion_group.add(Callback(lambda *args: glBlendFunc(GL_SRC_ALPHA, GL_ONE)))
-                    explosion_group.add(
-                        Rectangle(
-                            source="images/explosion.jpg",
-                            pos=(obstacle_widget.pos[0] - obstacle_widget.size[0] / 2, obstacle_widget.pos[1] - obstacle_widget.size[1] / 2),
-                            size=(obstacle_widget.size[0] * 3, obstacle_widget.size[1] * 3)
-                        )
+                    explosion = Rectangle(
+                        source="images/explosion.jpg",
+                        pos=(obstacle_widget.pos[0] - obstacle_widget.size[0] / 2, obstacle_widget.pos[1] - obstacle_widget.size[1] / 2),
+                        size=(obstacle_widget.size[0] * 3, obstacle_widget.size[1] * 3)
                     )
-                    explosion_group.add(Callback(lambda *args: glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)))
-                    self.explosions.append(explosion_group)
-                    self.canvas.add(explosion_group)
+                    self.explosions.append(explosion)
+                    self.canvas.add(explosion)
 
                     # "Remove" obstacle by making it size 0
                     obstacle_widget.size = (0, 0)
 
-                    Clock.schedule_once(lambda dt: self.remove_explosion(explosion_group), 0.5)
+                    Clock.schedule_once(lambda dt: self.remove_explosion(explosion), 0.5)
 
                     break
 
@@ -638,23 +632,18 @@ class MainWidget(RelativeLayout):
                         self.on_obstacle_destroyed()
 
                         # Add explosion
-                        explosion_group = InstructionGroup()
-                        explosion_group.add(Callback(lambda *args: glBlendFunc(GL_SRC_ALPHA, GL_ONE)))
-                        explosion_group.add(
-                            Rectangle(
-                                source="images/explosion.jpg",
-                                pos=(obstacle_widget.pos[0] - obstacle_widget.size[0] / 2, obstacle_widget.pos[1] - obstacle_widget.size[1] / 2),
-                                size=(obstacle_widget.size[0] * 3, obstacle_widget.size[1] * 3)
-                            )
+                        explosion = Rectangle(
+                            source="images/explosion.jpg",
+                            pos=(obstacle_widget.pos[0] - obstacle_widget.size[0] / 2, obstacle_widget.pos[1] - obstacle_widget.size[1] / 2),
+                            size=(obstacle_widget.size[0] * 3, obstacle_widget.size[1] * 3)
                         )
-                        explosion_group.add(Callback(lambda *args: glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)))
-                        self.explosions.append(explosion_group)
-                        self.canvas.add(explosion_group)
+                        self.explosions.append(explosion)
+                        self.canvas.add(explosion)
 
                         # "Remove" obstacle by making it size 0
                         obstacle_widget.size = (0, 0)
 
-                        Clock.schedule_once(lambda dt: self.remove_explosion(explosion_group), 0.5)
+                        Clock.schedule_once(lambda dt: self.remove_explosion(explosion), 0.5)
                     break
 
     def update_enemy_lasers(self):
@@ -707,20 +696,15 @@ class MainWidget(RelativeLayout):
                         self.on_obstacle_destroyed()
 
                         # Add explosion
-                        explosion_group = InstructionGroup()
-                        explosion_group.add(Callback(lambda *args: glBlendFunc(GL_SRC_ALPHA, GL_ONE)))
-                        explosion_group.add(
-                            Rectangle(
-                                source="images/explosion.jpg",
-                                pos=(obstacle_widget.pos[0] - obstacle_widget.size[0] / 2, obstacle_widget.pos[1] - obstacle_widget.size[1] / 2),
-                                size=(obstacle_widget.size[0] * 3, obstacle_widget.size[1] * 3)
-                            )
+                        explosion = Rectangle(
+                            source="images/explosion.jpg",
+                            pos=(obstacle_widget.pos[0] - obstacle_widget.size[0] / 2, obstacle_widget.pos[1] - obstacle_widget.size[1] / 2),
+                            size=(obstacle_widget.size[0] * 3, obstacle_widget.size[1] * 3)
                         )
-                        explosion_group.add(Callback(lambda *args: glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)))
-                        self.explosions.append(explosion_group)
-                        self.canvas.add(explosion_group)
+                        self.explosions.append(explosion)
+                        self.canvas.add(explosion)
                         obstacle_widget.size = (0, 0)
-                        Clock.schedule_once(lambda dt: self.remove_explosion(explosion_group), 0.5)
+                        Clock.schedule_once(lambda dt: self.remove_explosion(explosion), 0.5)
                         break
 
             # Collision with player (only for incoming lasers)
@@ -744,19 +728,14 @@ class MainWidget(RelativeLayout):
                     ship_center_x = self.ship.pos[0] + self.ship.size[0] / 2
                     ship_center_y = self.ship.pos[1] + self.ship.size[1] / 2
                     explosion_size = self.width * self.SHIP_WIDTH * 2.0
-                    explosion_group = InstructionGroup()
-                    explosion_group.add(Callback(lambda *args: glBlendFunc(GL_SRC_ALPHA, GL_ONE)))
-                    explosion_group.add(
-                        Rectangle(
-                            source="images/explosion.jpg",
-                            pos=(ship_center_x - explosion_size/2, ship_center_y - explosion_size/2),
-                            size=(explosion_size, explosion_size)
-                        )
+                    explosion = Rectangle(
+                        source="images/explosion.jpg",
+                        pos=(ship_center_x - explosion_size/2, ship_center_y - explosion_size/2),
+                        size=(explosion_size, explosion_size)
                     )
-                    explosion_group.add(Callback(lambda *args: glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)))
-                    self.explosions.append(explosion_group)
-                    self.canvas.add(explosion_group)
-                    Clock.schedule_once(lambda dt: self.remove_explosion(explosion_group), 0.5)
+                    self.explosions.append(explosion)
+                    self.canvas.add(explosion)
+                    Clock.schedule_once(lambda dt: self.remove_explosion(explosion), 0.5)
 
                     if self.lives == 0:
                         self.trigger_game_over()
@@ -797,21 +776,16 @@ class MainWidget(RelativeLayout):
                     self.on_obstacle_destroyed()
 
                     # Add explosion
-                    explosion_group = InstructionGroup()
-                    explosion_group.add(Callback(lambda *args: glBlendFunc(GL_SRC_ALPHA, GL_ONE)))
-                    explosion_group.add(
-                        Rectangle(
-                            source="images/explosion.jpg",
-                            pos=(obstacle_widget.pos[0] - obstacle_widget.size[0] / 2, obstacle_widget.pos[1] - obstacle_widget.size[1] / 2),
-                            size=(obstacle_widget.size[0] * 3, obstacle_widget.size[1] * 3)
-                        )
+                    explosion = Rectangle(
+                        source="images/explosion.jpg",
+                        pos=(obstacle_widget.pos[0] - obstacle_widget.size[0] / 2, obstacle_widget.pos[1] - obstacle_widget.size[1] / 2),
+                        size=(obstacle_widget.size[0] * 3, obstacle_widget.size[1] * 3)
                     )
-                    explosion_group.add(Callback(lambda *args: glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)))
-                    self.explosions.append(explosion_group)
-                    self.canvas.add(explosion_group)
+                    self.explosions.append(explosion)
+                    self.canvas.add(explosion)
 
                     obstacle_widget.size = (0, 0)
-                    Clock.schedule_once(lambda dt: self.remove_explosion(explosion_group), 0.5)
+                    Clock.schedule_once(lambda dt: self.remove_explosion(explosion), 0.5)
 
     def update(self, dt):
         if self.state_game_paused:
@@ -889,19 +863,14 @@ class MainWidget(RelativeLayout):
                 ship_center_x = self.ship.pos[0] + self.ship.size[0] / 2
                 ship_center_y = self.ship.pos[1] + self.ship.size[1] / 2
                 explosion_size = self.width * self.SHIP_WIDTH * 2.0
-                explosion_group = InstructionGroup()
-                explosion_group.add(Callback(lambda *args: glBlendFunc(GL_SRC_ALPHA, GL_ONE)))
-                explosion_group.add(
-                    Rectangle(
-                        source="images/explosion.jpg",
-                        pos=(ship_center_x - explosion_size/2, ship_center_y - explosion_size/2),
-                        size=(explosion_size, explosion_size)
-                    )
+                explosion = Rectangle(
+                    source="images/explosion.jpg",
+                    pos=(ship_center_x - explosion_size/2, ship_center_y - explosion_size/2),
+                    size=(explosion_size, explosion_size)
                 )
-                explosion_group.add(Callback(lambda *args: glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)))
-                self.explosions.append(explosion_group)
-                self.canvas.add(explosion_group)
-                Clock.schedule_once(lambda dt: self.remove_explosion(explosion_group), 0.5)
+                self.explosions.append(explosion)
+                self.canvas.add(explosion)
+                Clock.schedule_once(lambda dt: self.remove_explosion(explosion), 0.5)
 
                 if self.lives == 0:
                     self.trigger_game_over()
@@ -922,19 +891,14 @@ class MainWidget(RelativeLayout):
                         ship_center_x = self.ship.pos[0] + self.ship.size[0] / 2
                         ship_center_y = self.ship.pos[1] + self.ship.size[1] / 2
                         explosion_size = self.width * self.SHIP_WIDTH * 2.0
-                        explosion_group = InstructionGroup()
-                        explosion_group.add(Callback(lambda *args: glBlendFunc(GL_SRC_ALPHA, GL_ONE)))
-                        explosion_group.add(
-                            Rectangle(
-                                source="images/explosion.jpg",
-                                pos=(ship_center_x - explosion_size/2, ship_center_y - explosion_size/2),
-                                size=(explosion_size, explosion_size)
-                            )
+                        explosion = Rectangle(
+                            source="images/explosion.jpg",
+                            pos=(ship_center_x - explosion_size/2, ship_center_y - explosion_size/2),
+                            size=(explosion_size, explosion_size)
                         )
-                        explosion_group.add(Callback(lambda *args: glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)))
-                        self.explosions.append(explosion_group)
-                        self.canvas.add(explosion_group)
-                        Clock.schedule_once(lambda dt: self.remove_explosion(explosion_group), 0.5)
+                        self.explosions.append(explosion)
+                        self.canvas.add(explosion)
+                        Clock.schedule_once(lambda dt: self.remove_explosion(explosion), 0.5)
 
                         if self.lives == 0:
                             self.trigger_game_over()


### PR DESCRIPTION
This commit reverts the change that used additive blending for the explosion effect. The blending made the explosion invisible on your system.

This change brings back the simple `Rectangle` for the explosion, which will be visible but will have a square background.