### PR TITLE
Fix shield bugs and adjust player shield size

### DIFF
--- a/venv/galaxy.py
+++ b/venv/galaxy.py
@@ -596,7 +596,9 @@ class MainWidget(RelativeLayout):
                         if self.sound_shield:
                             self.sound_shield.play()
                         obstacle_dict['has_shield'] = False
-                        self.canvas.remove(obstacle_dict['shield_graphic'])
+                        if obstacle_dict['shield_graphic']:
+                            obstacle_dict['shield_graphic'].clear()
+                            self.canvas.remove(obstacle_dict['shield_graphic'])
                     else:
                         self.sound_explosion.play()
                         self.bullets.remove(bullet_dict)
@@ -717,7 +719,7 @@ class MainWidget(RelativeLayout):
 
     def update_shield(self):
         if self.shield_active:
-            shield_diameter = (self.ship.size[0]**2 + self.ship.size[1]**2)**0.5
+            shield_diameter = (self.ship.size[0]**2 + self.ship.size[1]**2)**0.5 * 0.8
             center_x = self.ship.pos[0] + self.ship.size[0] / 2
             center_y = self.ship.pos[1] + self.ship.size[1] / 2
 


### PR DESCRIPTION
This commit includes several fixes and enhancements:

- Fixes an `AttributeError` that occurred when updating obstacle shields. The fix involves storing a direct reference to the shield's `Line` instruction to avoid issues with Kivy's `InstructionGroup`'s children list.
- Reduces the size of the player's shield for better gameplay balance.
- Attempts to fix an issue where enemy shield reflections would remain on screen. The fix involves explicitly clearing the shield's `InstructionGroup` before removing it from the canvas to ensure all graphical elements are properly cleaned up.