### PR TITLE
Diagnostic: Player shield absorbs enemy lasers

### DIFF
--- a/venv/galaxy.py
+++ b/venv/galaxy.py
@@ -658,11 +658,11 @@ class MainWidget(RelativeLayout):
                 laser_y = laser.points[1]
                 distance = ((laser_x - center_x)**2 + (laser_y - center_y)**2)**0.5
                 if distance < shield_diameter / 2:
-                    laser_dict['velocity_y'] = -velocity # Reflect
-                    laser_dict['color'].rgb = self.CYAN
-                    # Speculative fix for player shield reflections
-                    self.canvas.remove(self.shield_instruction_group)
-                    self.canvas.add(self.shield_instruction_group)
+                    # Absorb laser (diagnostic)
+                    if self.sound_shield:
+                        self.sound_shield.play()
+                    self.enemy_lasers.remove(laser_dict)
+                    self.canvas.remove(laser_dict['group'])
                     continue
 
             # Collision with obstacles (only for reflected lasers)


### PR DESCRIPTION
This is a diagnostic commit to test the 'lingering player shield reflections' bug.

Changes the behavior of the player shield to absorb enemy lasers instead of reflecting them. This is to determine if the reflection logic itself is causing the graphical artifacts.

This commit also reverts the previous speculative fix of re-adding the shield to the canvas.