### PR TITLE
Final attempt to fix Tie Fighter shield reflections

### DIFF
--- a/venv/galaxy.py
+++ b/venv/galaxy.py
@@ -599,9 +599,18 @@ class MainWidget(RelativeLayout):
                         if self.sound_shield:
                             self.sound_shield.play()
                         obstacle_dict['has_shield'] = False
+                        # Scorched earth removal
                         shield_group = obstacle_dict['shield_graphic']
+                        shield_color = obstacle_dict['shield_color']
+                        shield_line = obstacle_dict['shield_line']
+
                         if shield_group:
+                            if shield_color:
+                                shield_color.rgba = (0, 0, 0, 0)
+                            if shield_line:
+                                shield_line.points = []
                             shield_group.clear()
+                            self.canvas.remove(shield_group)
                     else:
                         self.sound_explosion.play()
                         self.bullets.remove(bullet_dict)


### PR DESCRIPTION
This commit implements a "scorched earth" removal strategy for the Tie Fighter shields to definitively fix the lingering graphical artifacts issue.

- When a Tie Fighter shield is hit, it is now aggressively removed by:
  1. Making its Color instruction transparent.
  2. Clearing the points of its Line instruction.
  3. Clearing the `InstructionGroup`.
  4. Removing the `InstructionGroup` from the canvas.

This also includes the "re-creation" fix for player shield reflections, which was successful.