### PR TITLE
Fix: Game speed is now reset on restart

### DIFF
--- a/venv/galaxy.py
+++ b/venv/galaxy.py
@@ -178,6 +178,7 @@ class MainWidget(RelativeLayout):
         self.sound_energy.volume = .75
 
     def reset_game(self):
+        self.SPEED = self.NORMAL_SPEED
         self.current_offset_y = 0
         self.current_y_loop = 0
         self.current_speed_x = 0


### PR DESCRIPTION
This commit fixes a bug where the game speed would not reset to normal after a power-up if the game was restarted. The fix adds the speed reset logic to the `reset_game` method.